### PR TITLE
Update tests.js

### DIFF
--- a/exercises/23-The-Beatles/tests.js
+++ b/exercises/23-The-Beatles/tests.js
@@ -21,7 +21,7 @@ describe('All the javascript should match', function () {
 
         const file = require("./app.js");
 
-        expect(console.log).toHaveBeenCalledWith("let it be, let it be, let it be, let it be, words of wisdom, let it be, let it be, let it be, let it be, let it be, there will be an answer, let it be ");
+        expect(console.log).toHaveBeenCalledWith("let it be, let it be, let it be, let it be, words of wisdom, let it be, let it be, let it be, let it be, let it be, there will be an answer, let it be");
 
         expect(console.log.mock.calls.length).toBe(1);
     });


### PR DESCRIPTION
An extra space at the end of the string being tested will cause students to fail unexpectedly. I have removed the space to ensure the test will pass if they match what is showing on the example.