### PR TITLE
Fixed issue with exercise's Spanish readme

### DIFF
--- a/exercises/11-Your_first_if/README.es.md
+++ b/exercises/11-Your_first_if/README.es.md
@@ -8,11 +8,11 @@ La aplicación actual tiene una ventana que pregunta `How many km are left to go
 
 Una vez el usuario ingresa la cantidad, tenemos que imprimir una de las siguientes respuestas:
 
-1. Si quedan más de 100km, nosotros respondemos: `"We still have a bit of driving left to go?"`.
+1. Si quedan más de 100km, nosotros respondemos: `"We still have a bit of driving left to go"`.
 
 2. Si quedan más de 50km, nosotros respondemos: `"We'll be there in 5 minutes"`.
 
-3. Si quedan menos o igual a 50km, nosotros respondemos: `"I'm parking, I see you right now"`.
+3. Si quedan menos o igual a 50km, nosotros respondemos: `"I'm parking, I'll see you right now"`.
 
 ## 💡 Pista:
 


### PR DESCRIPTION
Instructions 1 and 3 expected result differed from English's README and tests' expected results.

"We still have a bit of driving left to go?" **should be** "We still have a bit of driving left to go"
"I'm parking, I see you right now" **should be** "I'm parking, I'll see you right now"